### PR TITLE
perf: track and leverage initial solution size

### DIFF
--- a/src/solvers/coin_cbc.rs
+++ b/src/solvers/coin_cbc.rs
@@ -23,7 +23,7 @@ pub fn coin_cbc(to_solve: UnsolvedProblem) -> CoinCbcProblem {
         variables,
     } = to_solve;
     let mut model = Model::default();
-    let mut initial_solution = vec![];
+    let mut initial_solution = Vec::with_capacity(variables.initial_solution_len());
     let columns: Vec<Col> = variables
         .iter_variables_with_def()
         .map(

--- a/src/solvers/scip.rs
+++ b/src/solvers/scip.rs
@@ -33,7 +33,7 @@ pub fn scip(to_solve: UnsolvedProblem) -> SCIPProblem {
             ObjectiveDirection::Minimisation => ObjSense::Minimize,
         });
     let mut var_map = HashMap::new();
-    let mut initial_solution = vec![];
+    let mut initial_solution = Vec::with_capacity(to_solve.variables.initial_solution_len());
 
     for (
         var,

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -421,6 +421,15 @@ impl ProblemVariables {
     }
 
     /// Returns the number of variables with initial solution values
+    ///
+    /// ```
+    /// use good_lp::{variable, variables};
+    /// let mut vars = variables!();
+    /// vars.add(variable());
+    /// vars.add(variable().initial(5));
+    /// vars.add(variable());
+    /// assert_eq!(vars.initial_solution_len(), 1);
+    /// ```
     pub fn initial_solution_len(&self) -> usize {
         self.initial_count
     }

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -285,12 +285,16 @@ pub fn variable() -> VariableDefinition {
 #[derive(Default)]
 pub struct ProblemVariables {
     variables: Vec<VariableDefinition>,
+    initial_count: usize,
 }
 
 impl ProblemVariables {
     /// Create an empty list of variables
     pub fn new() -> Self {
-        ProblemVariables { variables: vec![] }
+        ProblemVariables {
+            variables: vec![],
+            initial_count: 0,
+        }
     }
 
     /// Add a anonymous unbounded continuous variable to the problem
@@ -312,6 +316,9 @@ impl ProblemVariables {
     /// ```
     pub fn add(&mut self, var_def: VariableDefinition) -> Variable {
         let index = self.variables.len();
+        if var_def.initial.is_some() {
+            self.initial_count += 1;
+        }
         self.variables.push(var_def);
         Variable::at(index)
     }
@@ -411,6 +418,11 @@ impl ProblemVariables {
     /// Returns true when no variables have been added
     pub fn is_empty(&self) -> bool {
         self.variables.is_empty()
+    }
+
+    /// Returns the number of variables with initial solution values
+    pub fn initial_solution_len(&self) -> usize {
+        self.initial_count
     }
 
     /// Display the given expression or constraint with the correct variable names


### PR DESCRIPTION
Previously, when building up an initial solution from the problem variables would cause repeated reallocation. We support partial initial solutions so we may have 0-n values in the initial solution (with n being the number of total variables). We do not want to allocate memory for all variables because there might be 0 initial values, and we also do not want to do allocate 0 memory because then we have to repeatedly reallocate memory as the initial solution grows.

These changes introduce a counter that is incrememted whenever a variable with an initial value is added to the problem. That way, we can allocate the perfect number of bytes upfront in all cases.